### PR TITLE
feat: add paragraph and page number post-processing options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { DatalabConverter } from './converters/datalabConverter';
 import { MarkerApiDockerConverter } from './converters/markerApiDocker';
 import { PythonAPIConverter } from './converters/markerPythonApi';
 import { MistralAIConverter } from './converters/mistralaiConverter';
+import { MarkerNumberInputDialog } from './modals';
 
 export default class Marker extends Plugin {
   settings: MarkerSettings;
@@ -95,11 +96,27 @@ export default class Marker extends Plugin {
   }
 
   private async convertFile(file: TFile) {
-    if (this.converter) {
-      await this.converter.convert(this.app, this.settings, file);
-    } else {
+    if (!this.converter) {
       console.error('No converter initialized.');
+      return;
     }
+
+    // If page numbering is on, ask for the starting page before sending to the API
+    if (this.settings.addPageNumbers) {
+      const pageStart = await new Promise<number | null>((resolve) => {
+        new MarkerNumberInputDialog(
+          this.app,
+          'Starting page number',
+          `What is the page number of the first page in "${file.name}"?`,
+          1,
+          resolve
+        ).open();
+      });
+      if (pageStart === null) return; // user cancelled
+      this.settings.pageNumberStart = pageStart;
+    }
+
+    await this.converter.convert(this.app, this.settings, file);
   }
 
   private addCommands() {

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -53,6 +53,71 @@ export class MarkerOkayCancelDialog extends Modal {
   }
 }
 
+export class MarkerNumberInputDialog extends Modal {
+  private onSubmit: (result: number | null) => void;
+  private title: string;
+  private message: string;
+  private defaultValue: number;
+
+  constructor(
+    app: App,
+    title: string,
+    message: string,
+    defaultValue: number,
+    onSubmit: (result: number | null) => void
+  ) {
+    super(app);
+    this.title = title;
+    this.message = message;
+    this.defaultValue = defaultValue;
+    this.onSubmit = onSubmit;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.createEl('h2', { text: this.title });
+    contentEl.createEl('p', { text: this.message });
+
+    const input = contentEl.createEl('input', {
+      attr: {
+        type: 'number',
+        value: String(this.defaultValue),
+        min: '1',
+        style: 'width: 100%; margin-bottom: 1em;',
+      },
+    }) as HTMLInputElement;
+    input.focus();
+    input.select();
+
+    const buttonContainer = contentEl.createEl('div', {
+      attr: { class: 'modal-button-container' },
+    });
+    const okButton = buttonContainer.createEl('button', {
+      text: 'Confirm',
+      attr: { class: 'mod-cta' },
+    });
+    okButton.addEventListener('click', () => {
+      const num = parseInt(input.value);
+      this.onSubmit(isNaN(num) ? 1 : num);
+      this.close();
+    });
+    const cancelButton = buttonContainer.createEl('button', { text: 'Cancel' });
+    cancelButton.addEventListener('click', () => {
+      this.onSubmit(null);
+      this.close();
+    });
+
+    input.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') okButton.click();
+    });
+  }
+
+  onClose() {
+    const { contentEl } = this;
+    contentEl.empty();
+  }
+}
+
 export class MarkerSupportedLangsDialog extends Modal {
   title: string;
   message: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,10 @@ export interface MarkerSettings {
   // MistralAI parameters
   imageLimit?: number;
   imageMinSize?: number; // Minimum height and width of images to extract
+  // Post-processing options
+  addPageNumbers?: boolean;
+  pageNumberStart?: number;
+  addParagraphNumbers?: boolean;
 }
 
 export const DEFAULT_SETTINGS: MarkerSettings = {
@@ -51,6 +55,9 @@ export const DEFAULT_SETTINGS: MarkerSettings = {
   skipCache: false,
   imageLimit: 0,
   imageMinSize: 0, // Default to 0 (no minimum size)
+  addPageNumbers: false,
+  pageNumberStart: 1,
+  addParagraphNumbers: false,
 };
 
 export class MarkerSettingTab extends PluginSettingTab {
@@ -182,6 +189,53 @@ export class MarkerSettingTab extends PluginSettingTab {
           })
       );
 
+    // Add a heading for post-processing settings
+    containerEl.createEl('h3', { text: 'Post-Processing' });
+
+    // Page number start input — declared before addPageNumbers toggle so its closure can reference it
+    const pageNumberStartSetting = new Setting(containerEl)
+      .setName('Page number start')
+      .setDesc('The page number of the first page in the PDF')
+      .addText((text) =>
+        text
+          .setPlaceholder('1')
+          .setValue(String(this.plugin.settings.pageNumberStart ?? 1))
+          .onChange(async (value) => {
+            const num = parseInt(value);
+            this.plugin.settings.pageNumberStart = isNaN(num) ? 1 : num;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Add page numbers')
+      .setDesc(
+        "Insert an italic page label (e.g. *Page 1*) above each page-break separator (---). Requires 'Paginate output' to be enabled in Converter Settings."
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.addPageNumbers ?? false)
+          .onChange(async (value) => {
+            this.plugin.settings.addPageNumbers = value;
+            await this.plugin.saveSettings();
+            updatePageNumberStartSetting(value);
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Add paragraph numbers')
+      .setDesc(
+        'Prefix each prose paragraph with [¶N] to aid citation and verification. Skips headings, code blocks, tables, lists, images, and page separators.'
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.addParagraphNumbers ?? false)
+          .onChange(async (value) => {
+            this.plugin.settings.addParagraphNumbers = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
     // Helper function to update the state of the 'Move PDF to Folder' setting
     const updateMovePDFSetting = (createFolderEnabled: boolean) => {
       this.plugin.settings.movePDFtoFolder =
@@ -198,8 +252,14 @@ export class MarkerSettingTab extends PluginSettingTab {
       writeMetadataToggle.settingEl.toggle(canWriteMetadata);
     };
 
+    // Helper function to show/hide the page number start input
+    const updatePageNumberStartSetting = (enabled: boolean) => {
+      pageNumberStartSetting.settingEl.toggle(enabled);
+    };
+
     // Initialize settings state
     updateMovePDFSetting(this.plugin.settings.createFolder);
     updateWriteMetadataSetting(this.plugin.settings.extractContent);
+    updatePageNumberStartSetting(this.plugin.settings.addPageNumbers ?? false);
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -28,8 +28,9 @@ export interface MarkerSettings {
   imageMinSize?: number; // Minimum height and width of images to extract
   // Post-processing options
   addPageNumbers?: boolean;
-  pageNumberStart?: number;
+  pageNumberStart?: number; // set at runtime via modal, not persisted in UI
   addParagraphNumbers?: boolean;
+  splitLargeFiles?: boolean;
 }
 
 export const DEFAULT_SETTINGS: MarkerSettings = {
@@ -58,6 +59,7 @@ export const DEFAULT_SETTINGS: MarkerSettings = {
   addPageNumbers: false,
   pageNumberStart: 1,
   addParagraphNumbers: false,
+  splitLargeFiles: false,
 };
 
 export class MarkerSettingTab extends PluginSettingTab {
@@ -192,25 +194,10 @@ export class MarkerSettingTab extends PluginSettingTab {
     // Add a heading for post-processing settings
     containerEl.createEl('h3', { text: 'Post-Processing' });
 
-    // Page number start input — declared before addPageNumbers toggle so its closure can reference it
-    const pageNumberStartSetting = new Setting(containerEl)
-      .setName('Page number start')
-      .setDesc('The page number of the first page in the PDF')
-      .addText((text) =>
-        text
-          .setPlaceholder('1')
-          .setValue(String(this.plugin.settings.pageNumberStart ?? 1))
-          .onChange(async (value) => {
-            const num = parseInt(value);
-            this.plugin.settings.pageNumberStart = isNaN(num) ? 1 : num;
-            await this.plugin.saveSettings();
-          })
-      );
-
     new Setting(containerEl)
       .setName('Add page numbers')
       .setDesc(
-        "Insert an italic page label (e.g. *Page 1*) above each page-break separator (---). Requires 'Paginate output' to be enabled in Converter Settings."
+        "Insert an italic page label (e.g. *Page 1*) above each page-break separator (---). You will be prompted for the starting page number each time you convert. Requires 'Paginate output' to be enabled in Converter Settings."
       )
       .addToggle((toggle) =>
         toggle
@@ -218,7 +205,6 @@ export class MarkerSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.addPageNumbers = value;
             await this.plugin.saveSettings();
-            updatePageNumberStartSetting(value);
           })
       );
 
@@ -232,6 +218,20 @@ export class MarkerSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.addParagraphNumbers ?? false)
           .onChange(async (value) => {
             this.plugin.settings.addParagraphNumbers = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Split large files')
+      .setDesc(
+        'If the converted markdown exceeds 20,000 words, split it into multiple files (filename.md, filename-part-2.md, …). Paragraph and page numbers continue across parts.'
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.splitLargeFiles ?? false)
+          .onChange(async (value) => {
+            this.plugin.settings.splitLargeFiles = value;
             await this.plugin.saveSettings();
           })
       );
@@ -252,14 +252,8 @@ export class MarkerSettingTab extends PluginSettingTab {
       writeMetadataToggle.settingEl.toggle(canWriteMetadata);
     };
 
-    // Helper function to show/hide the page number start input
-    const updatePageNumberStartSetting = (enabled: boolean) => {
-      pageNumberStartSetting.settingEl.toggle(enabled);
-    };
-
     // Initialize settings state
     updateMovePDFSetting(this.plugin.settings.createFolder);
     updateWriteMetadataSetting(this.plugin.settings.extractContent);
-    updatePageNumberStartSetting(this.plugin.settings.addPageNumbers ?? false);
   }
 }

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -149,6 +149,14 @@ export async function createMarkdownFile(
     markdown = markdown.replace(/!\[.*\]\(.*\)/g, '');
   }
 
+  // Page numbers must run before paragraph numbers so *Page N* labels are not themselves numbered
+  if (settings.addPageNumbers) {
+    markdown = addPageNumbersToMarkdown(markdown, settings.pageNumberStart ?? 1);
+  }
+  if (settings.addParagraphNumbers) {
+    markdown = addParagraphNumbersToMarkdown(markdown);
+  }
+
   const existingFile = app.vault.getAbstractFileByPath(filePath);
   if (existingFile instanceof TFile) {
     file = existingFile;
@@ -180,6 +188,65 @@ export async function addMetadataToMarkdownFile(
         console.error('Error adding metadata to markdown file:', error);
       });
   }
+}
+
+function addPageNumbersToMarkdown(markdown: string, startPage: number): string {
+  let pageNumber = startPage;
+  return markdown.replace(/\n\n---\n\n/g, () => {
+    const label = `\n\n*Page ${pageNumber}*\n\n---\n\n`;
+    pageNumber++;
+    return label;
+  });
+}
+
+function addParagraphNumbersToMarkdown(markdown: string): string {
+  // Extract YAML frontmatter so it is never numbered
+  let frontmatter = '';
+  let body = markdown;
+  const frontmatterMatch = markdown.match(/^---\n[\s\S]*?\n---\n/);
+  if (frontmatterMatch) {
+    frontmatter = frontmatterMatch[0];
+    body = markdown.slice(frontmatter.length);
+  }
+
+  const blocks = body.split(/\n\n/);
+
+  const isNonProse = (block: string): boolean => {
+    const t = block.trimStart();
+    if (t === '') return true;
+    if (/^#{1,6}\s/.test(t)) return true;    // headings
+    if (/^---+\s*$/.test(t)) return true;    // horizontal rules / page separators
+    if (/^```/.test(t)) return true;          // fenced code blocks
+    if (/^\|/.test(t)) return true;           // tables
+    if (/^>/.test(t)) return true;            // blockquotes
+    if (/^\s*[-*+]\s/.test(t)) return true;   // unordered lists
+    if (/^\s*\d+\.\s/.test(t)) return true;   // ordered lists
+    if (/^!\[/.test(t)) return true;          // images
+    if (/^\*Page \d+\*/.test(t)) return true; // page labels inserted by addPageNumbersToMarkdown
+    return false;
+  };
+
+  // Track whether we are inside a fenced code block across blank-line-split fragments
+  let insideCodeFence = false;
+  let paragraphNumber = 1;
+
+  const numberedBlocks = blocks.map((block) => {
+    const fenceCount = (block.match(/^```/gm) || []).length;
+    const startsWithFence = /^```/.test(block.trimStart());
+
+    if (insideCodeFence) {
+      if (fenceCount % 2 === 1) insideCodeFence = false;
+      return block;
+    }
+    if (startsWithFence) {
+      if (fenceCount % 2 === 1) insideCodeFence = true;
+      return block;
+    }
+    if (isNonProse(block)) return block;
+    return `[¶${paragraphNumber++}] ${block.trimStart()}`;
+  });
+
+  return frontmatter + numberedBlocks.join('\n\n');
 }
 
 function generateFrontmatter(metadata: { [key: string]: any }): string {

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -122,6 +122,8 @@ export async function createImageFiles(
   }
 }
 
+const WORD_SPLIT_THRESHOLD = 20000;
+
 export async function createMarkdownFile(
   app: App,
   settings: MarkerSettings,
@@ -129,7 +131,8 @@ export async function createMarkdownFile(
   folderPath: string,
   originalFile: TFile
 ) {
-  const fileName = originalFile.name.split('.')[0] + '.md';
+  const baseName = originalFile.name.split('.')[0];
+  const fileName = baseName + '.md';
   const filePath = folderPath + fileName;
   let file: TFile;
 
@@ -155,6 +158,29 @@ export async function createMarkdownFile(
   }
   if (settings.addParagraphNumbers) {
     markdown = addParagraphNumbersToMarkdown(markdown);
+  }
+
+  // Split into multiple files if the document exceeds the word threshold
+  if (settings.splitLargeFiles) {
+    const wordCount = markdown.trim().split(/\s+/).filter((s) => s.length > 0).length;
+    if (wordCount > WORD_SPLIT_THRESHOLD) {
+      const chunks = splitMarkdownIntoChunks(markdown, WORD_SPLIT_THRESHOLD);
+      for (let i = 0; i < chunks.length; i++) {
+        const partName = i === 0 ? fileName : `${baseName}-part-${i + 1}.md`;
+        const partPath = folderPath + partName;
+        const existing = app.vault.getAbstractFileByPath(partPath);
+        let partFile: TFile;
+        if (existing instanceof TFile) {
+          partFile = existing;
+          await app.vault.modify(partFile, chunks[i]);
+        } else {
+          partFile = await app.vault.create(partPath, chunks[i]);
+        }
+        new Notice(`Markdown file created: ${partName}`);
+        if (i === 0) app.workspace.openLinkText(partFile.path, '', true);
+      }
+      return;
+    }
   }
 
   const existingFile = app.vault.getAbstractFileByPath(filePath);
@@ -188,6 +214,31 @@ export async function addMetadataToMarkdownFile(
         console.error('Error adding metadata to markdown file:', error);
       });
   }
+}
+
+function splitMarkdownIntoChunks(markdown: string, maxWords: number): string[] {
+  const blocks = markdown.split(/\n\n/);
+  const chunks: string[] = [];
+  let currentBlocks: string[] = [];
+  let currentWordCount = 0;
+
+  for (const block of blocks) {
+    const blockWords = block.trim().split(/\s+/).filter((s) => s.length > 0).length;
+    if (currentWordCount + blockWords > maxWords && currentBlocks.length > 0) {
+      chunks.push(currentBlocks.join('\n\n'));
+      currentBlocks = [block];
+      currentWordCount = blockWords;
+    } else {
+      currentBlocks.push(block);
+      currentWordCount += blockWords;
+    }
+  }
+
+  if (currentBlocks.length > 0) {
+    chunks.push(currentBlocks.join('\n\n'));
+  }
+
+  return chunks;
 }
 
 function addPageNumbersToMarkdown(markdown: string, startPage: number): string {


### PR DESCRIPTION
## Summary

Adds three optional post-processing features to help with citation and verification when using converted PDFs as research sources. All are disabled by default and live under a new **Post-Processing** section in plugin settings.

- **Add page numbers**: inserts an italic `*Page N*` label above each `---` page-break separator (produced when *Paginate output* is enabled). When this is on, a dialog appears **before each conversion** asking for the starting page number of that specific PDF — no need to touch settings between documents.

- **Add paragraph numbers**: prefixes each prose paragraph with `[¶N]`. You can ask an AI to cite paragraph numbers when summarising a document, then verify claims against the source. Skips headings, code blocks, tables, lists, blockquotes, images, and YAML frontmatter — only plain prose paragraphs are numbered.

- **Split large files**: if the converted markdown exceeds 20,000 words, the output is split at paragraph boundaries into `filename.md`, `filename-part-2.md`, etc. Paragraph and page numbers are continuous across all parts. Prevents performance issues with very large documents in Obsidian.

## Implementation details

- All changes are pure post-processing — the conversion pipeline is untouched.
- Page numbers run before paragraph numbers so `*Page N*` labels are never assigned a `[¶N]` prefix.
- The paragraph numbering helper tracks fenced code blocks across blank-line splits so code blocks with internal blank lines are handled correctly.
- File splitting happens after all other post-processing; chunks are split on `\n\n` boundaries so no paragraph is broken mid-sentence.
- The page-start value is set on the `settings` object at runtime (not saved to disk) so each conversion can have its own starting page without persisting a stale value.

## Files changed

- `src/modals.ts` — new `MarkerNumberInputDialog` class (number input with confirm/cancel)
- `src/main.ts` — `convertFile()` shows the page-start prompt before conversion when page numbering is on
- `src/settings.ts` — `splitLargeFiles` field + Post-Processing UI section (page-start setting removed from UI, now prompt-driven)
- `src/utils/fileUtils.ts` — `splitMarkdownIntoChunks()` helper + splitting logic in `createMarkdownFile()`

## Test plan

- [ ] Convert a multi-page PDF with *Paginate output* + *Add page numbers* on — confirm the page-start dialog appears, `*Page N*` labels appear above each `---`, and the correct starting number is used
- [ ] Convert a second PDF without reopening settings — confirm the dialog prompts again independently
- [ ] Cancel the page-start dialog — confirm conversion is aborted cleanly
- [ ] Convert a PDF with *Add paragraph numbers* on — confirm `[¶1]`, `[¶2]`… appear on prose; headings, code blocks, lists, tables, and images are **not** numbered
- [ ] Enable both page + paragraph numbers — confirm page labels are not assigned paragraph numbers
- [ ] Convert a large PDF (>20,000 words) with *Split large files* on — confirm multiple part files are created with continuous numbering
- [ ] Disable all three features — confirm output is identical to current behaviour (no regression)
- [ ] `npm run build` passes with no TypeScript errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)