### PR TITLE
[New Feature] Support Remote Python API Servers (Cloud / WSL)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-marker",
-	"version": "1.4.4",
+	"version": "1.4.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-marker",
-			"version": "1.4.4",
+			"version": "1.4.8",
 			"license": "MIT",
 			"dependencies": {
 				"@mistralai/mistralai": "^1.5.2"

--- a/src/converters/datalabConverter.ts
+++ b/src/converters/datalabConverter.ts
@@ -4,6 +4,7 @@ import { BaseConverter, ConversionResult } from './../converter';
 import { checkForExistingFiles } from '../utils/fileUtils';
 import { ConverterSettingDefinition } from '../utils/converterSettingsUtils';
 import { MarkerSupportedLangsDialog } from '../modals';
+import {FormField, MarkerMultipartRequest} from "../utils/multipartUtils";
 
 // Define interfaces for Datalab API responses
 interface DatalabInitialResponse {
@@ -24,12 +25,6 @@ interface DatalabFinalResponse {
   success?: boolean | null;
   error?: string | null;
   page_count?: number | null;
-}
-
-// Interface for multipart form field
-interface FormField {
-  name: string;
-  value: string | boolean | number | null;
 }
 
 export class DatalabConverter extends BaseConverter {
@@ -271,104 +266,7 @@ export class DatalabConverter extends BaseConverter {
     }
 
     // Build the multipart form data
-    return this.buildMultipartRequest(boundary, file, fileContent, fields);
-  }
-
-  /**
-   * Builds the multipart request body
-   */
-  private buildMultipartRequest(
-    boundary: string,
-    file: TFile,
-    fileContent: ArrayBuffer,
-    fields: FormField[]
-  ): { body: ArrayBuffer; boundary: string } {
-    const parts: (string | Uint8Array)[] = [];
-
-    // Add the file part
-    const contentType = this.getContentTypeForFile(file);
-    parts.push(
-      `--${boundary}\r\n` +
-        `Content-Disposition: form-data; name="file"; filename="${file.name}"\r\n` +
-        `Content-Type: ${contentType}\r\n\r\n`
-    );
-    parts.push(new Uint8Array(fileContent));
-    parts.push('\r\n');
-
-    // Add other form fields
-    for (const field of fields) {
-      if (field.value !== null && field.value !== undefined) {
-        parts.push(
-          `--${boundary}\r\n` +
-            `Content-Disposition: form-data; name="${field.name}"\r\n\r\n${field.value}\r\n`
-        );
-      }
-    }
-
-    // Add closing boundary
-    parts.push(`--${boundary}--\r\n`);
-
-    // Combine all parts into a single ArrayBuffer
-    return {
-      body: this.combinePartsToArrayBuffer(parts),
-      boundary: boundary,
-    };
-  }
-
-  /**
-   * Determines the content type for a file based on its extension
-   */
-  private getContentTypeForFile(file: TFile): string {
-    switch (file.extension) {
-      case 'pdf':
-        return 'application/pdf';
-      case 'docx':
-      case 'doc':
-        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-      case 'pptx':
-      case 'ppt':
-        return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
-      case 'jpg':
-      case 'jpeg':
-        return 'image/jpeg';
-      case 'png':
-        return 'image/png';
-      case 'webp':
-        return 'image/webp';
-      default:
-        console.error(
-          `Unrecognized file extension: ${file.extension}, using generic content type`
-        );
-        return 'application/octet-stream';
-    }
-  }
-
-  /**
-   * Combines parts into a single ArrayBuffer
-   */
-  private combinePartsToArrayBuffer(
-    parts: (string | Uint8Array)[]
-  ): ArrayBuffer {
-    // Convert string parts to Uint8Array
-    const bodyParts = parts.map((part) =>
-      typeof part === 'string' ? new TextEncoder().encode(part) : part
-    );
-
-    // Calculate total length
-    const bodyLength = bodyParts.reduce(
-      (acc, part) => acc + part.byteLength,
-      0
-    );
-
-    // Create and fill the combined buffer
-    const body = new Uint8Array(bodyLength);
-    let offset = 0;
-    for (const part of bodyParts) {
-      body.set(part, offset);
-      offset += part.byteLength;
-    }
-
-    return body.buffer;
+    return MarkerMultipartRequest.build(boundary, file, fileContent, fields);
   }
 
   async testConnection(

--- a/src/converters/markerApiDocker.ts
+++ b/src/converters/markerApiDocker.ts
@@ -3,6 +3,7 @@ import { MarkerSettings } from './../settings';
 import { BaseConverter, ConversionResult } from './../converter';
 import { checkForExistingFiles } from '../utils/fileUtils';
 import { ConverterSettingDefinition } from '../utils/converterSettingsUtils';
+import {MarkerMultipartRequest} from "../utils/multipartUtils";
 
 // Define interfaces for Docker API responses based on OpenAPI spec
 interface GeneralMetadata {
@@ -230,24 +231,12 @@ export class MarkerApiDockerConverter extends BaseConverter {
     parts.push(`--${boundary}--\r\n`);
 
     // Combine all parts into a single ArrayBuffer
-    const bodyParts = parts.map((part) =>
-      typeof part === 'string' ? new TextEncoder().encode(part) : part
-    );
-    const bodyLength = bodyParts.reduce(
-      (acc, part) => acc + part.byteLength,
-      0
-    );
-    const body = new Uint8Array(bodyLength);
-    let offset = 0;
-    for (const part of bodyParts) {
-      body.set(part, offset);
-      offset += part.byteLength;
-    }
+    const bodyParts = MarkerMultipartRequest.combinePartsToArrayBuffer(parts);
 
     const requestParams: RequestUrlParam = {
       url: `http://${settings.markerEndpoint}/convert`,
       method: 'POST',
-      body: body.buffer,
+      body: bodyParts,
       headers: {
         'Content-Type': `multipart/form-data; boundary=${boundary}`,
       },

--- a/src/converters/markerCloudPythonApi.ts
+++ b/src/converters/markerCloudPythonApi.ts
@@ -31,7 +31,7 @@ interface PythonApiErrorResponse {
   detail: PythonApiErrorDetail[];
 }
 
-export class PythonAPIConverter extends BaseConverter {
+export class PythonCloudAPIConverter extends BaseConverter {
   async convert(
     app: App,
     settings: MarkerSettings,

--- a/src/converters/markerCloudPythonApi.ts
+++ b/src/converters/markerCloudPythonApi.ts
@@ -1,0 +1,281 @@
+import {
+  App,
+  Notice,
+  TFile,
+  requestUrl,
+  RequestUrlParam,
+  FileSystemAdapter,
+} from 'obsidian';
+import { MarkerSettings } from './../settings';
+import { BaseConverter, ConversionResult } from './../converter';
+import { deleteOriginalFile } from '../utils/fileUtils';
+import { ConverterSettingDefinition } from '../utils/converterSettingsUtils';
+import {FormField, MarkerMultipartRequest} from "../utils/multipartUtils";
+
+// Define interfaces for Python API responses
+interface PythonApiSuccessResponse {
+  format: string;
+  output: string;
+  images: Record<string, string>;
+  metadata: Record<string, any>;
+  success: boolean;
+}
+
+interface PythonApiErrorDetail {
+  loc: [string, number];
+  msg: string;
+  type: string;
+}
+
+interface PythonApiErrorResponse {
+  detail: PythonApiErrorDetail[];
+}
+
+export class PythonAPIConverter extends BaseConverter {
+  async convert(
+    app: App,
+    settings: MarkerSettings,
+    file: TFile
+  ): Promise<boolean> {
+    const folderPath = await this.prepareConversion(settings, file);
+    if (!folderPath) return false;
+
+    new Notice('Converting file with Python API...', 10000);
+
+    try {
+      let fileContent: ArrayBuffer;
+
+      try {
+        fileContent = await app.vault.readBinary(file);
+      } catch (readError) {
+        console.error(
+          `Failed to read file content: ${readError.message}`,
+          readError
+        );
+
+        new Notice(
+          `Error reading file: ${readError.message || 'Access denied'}`
+        );
+
+        return false;
+      }
+
+      const multipart = await this.createMultipartFormData(
+        file,
+        fileContent,
+        settings
+      );
+
+      const requestParams: RequestUrlParam = {
+        url: `http://${settings.pythonEndpoint}/marker/upload`,
+        method: 'POST',
+        throw: false,
+        headers: {
+          'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+        },
+        body: multipart.body,
+      };
+
+      const response = await requestUrl(requestParams);
+
+      if (response.status !== 200) {
+        try {
+          const errorData = JSON.parse(
+            response.text
+          ) as PythonApiErrorResponse;
+
+          let errorMsg = `HTTP ${response.status}`;
+
+          if (errorData.detail?.length) {
+            errorMsg = errorData.detail
+              .map((err) => err.msg)
+              .join('; ');
+          }
+
+          console.error('Python API error response:', errorData);
+          new Notice(`Python API conversion failed: ${errorMsg}`);
+          return false;
+        } catch {
+          console.error(
+            `Python API error: HTTP ${response.status}`,
+            response.text
+          );
+
+          new Notice(
+            `Python API conversion failed: HTTP ${response.status} - ${
+              response.text
+                ? response.text.substring(0, 100)
+                : 'No response details'
+            }`
+          );
+
+          return false;
+        }
+      }
+
+      const responseData = JSON.parse(
+        response.text
+      ) as PythonApiSuccessResponse;
+
+      const conversionResult: ConversionResult = {
+        success: responseData.success || false,
+        markdown: responseData.output || '',
+        images: responseData.images || {},
+        metadata: responseData.metadata || {},
+      };
+
+      if (!conversionResult.success) {
+        conversionResult.error = 'Unknown conversion error';
+
+        console.error(
+          `Python API conversion failed: ${conversionResult.error}`,
+          responseData
+        );
+
+        new Notice(
+          `Python API conversion failed: ${conversionResult.error}`
+        );
+
+        return false;
+      }
+
+      await this.processConversionResult(
+        app,
+        settings,
+        conversionResult,
+        folderPath,
+        file
+      );
+
+      new Notice('Conversion with Python API completed');
+
+      if (settings.movePDFtoFolder) {
+        const newFilePath = folderPath + file.name;
+        await app.vault.rename(file, newFilePath);
+      }
+
+      if (settings.deleteOriginal) {
+        await deleteOriginalFile(app, file);
+      }
+
+      return true;
+    } catch (error) {
+      console.error(
+        'Python API conversion error:',
+        error.message,
+        error.stack
+      );
+
+      new Notice(
+        `Python API conversion failed: ${
+          error.message || 'Network or server error'
+        }`
+      );
+
+      return false;
+    }
+  }
+
+  /**
+   * Creates multipart form data for the API request
+   */
+  private async createMultipartFormData(
+    file: TFile,
+    fileContent: ArrayBuffer,
+    settings: MarkerSettings
+  ): Promise<{ body: ArrayBuffer; boundary: string }> {
+    const boundary =
+      '----WebKitFormBoundary' + Math.random().toString(36).substring(2);
+
+    const fields: FormField[] = [
+      {
+        name: 'page_range',
+        value: '',
+      },
+      {
+        name: 'force_ocr',
+        value: settings.forceOCR ?? false,
+      },
+      {
+        name: 'paginate_output',
+        value: settings.paginate ?? false,
+      },
+      {
+        name: 'output_format',
+        value: 'markdown',
+      },
+    ];
+
+    return MarkerMultipartRequest.build(
+      boundary,
+      file,
+      fileContent,
+      fields
+    );
+  }
+
+  async testConnection(
+    settings: MarkerSettings,
+    silent: boolean | undefined
+  ): Promise<boolean> {
+    try {
+      const requestParams: RequestUrlParam = {
+        url: `http://${settings.pythonEndpoint}/`,
+        method: 'GET',
+        throw: false,
+      };
+      const response = await requestUrl(requestParams);
+      if (response.status === 200) {
+        if (!silent) new Notice('Connection successful!');
+        return true;
+      } else {
+        new Notice(`Error connecting to Python API: ${response.status}`);
+        return false;
+      }
+    } catch (error) {
+      new Notice('Error connecting to Python API');
+      console.error('Error connecting to Python API:', error);
+      return false;
+    }
+  }
+
+  getConverterSettings(): ConverterSettingDefinition[] {
+    return [
+      {
+        id: 'pythonEndpoint',
+        name: 'Python API address',
+        description: 'The endpoint to use for the Python API.',
+        type: 'text',
+        placeholder: 'localhost:8001',
+        defaultValue: 'localhost:8001',
+        buttonText: 'Test connection',
+        buttonAction: async (app, settings) => {
+          await this.testConnection(settings, false);
+        },
+      },
+      {
+        id: 'langs',
+        name: 'Languages',
+        description:
+          'The languages to use if OCR is needed, separated by commas',
+        type: 'text',
+        placeholder: 'en',
+        defaultValue: 'en',
+      },
+      {
+        id: 'forceOCR',
+        name: 'Force OCR',
+        description: 'Force OCR (Activate this when auto-detect often fails)',
+        type: 'toggle',
+        defaultValue: false,
+      },
+      {
+        id: 'paginate',
+        name: 'Paginate',
+        description: 'Add horizontal rules between each page',
+        type: 'toggle',
+        defaultValue: false,
+      },
+    ];
+  }
+}

--- a/src/converters/markerLocalPythonApi.ts
+++ b/src/converters/markerLocalPythonApi.ts
@@ -30,7 +30,7 @@ interface PythonApiErrorResponse {
   detail: PythonApiErrorDetail[];
 }
 
-export class PythonAPIConverter extends BaseConverter {
+export class PythonLocalAPIConverter extends BaseConverter {
   async convert(
     app: App,
     settings: MarkerSettings,

--- a/src/converters/markerLocalPythonApi.ts
+++ b/src/converters/markerLocalPythonApi.ts
@@ -147,7 +147,7 @@ export class PythonAPIConverter extends BaseConverter {
           parseError,
           'Response text:',
           response.text.substring(0, 500) +
-            (response.text.length > 500 ? '...' : '')
+          (response.text.length > 500 ? '...' : '')
         );
         new Notice(
           'Error parsing Python API response. Check console for details.'

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,8 @@ import { MarkerSettings, DEFAULT_SETTINGS, MarkerSettingTab } from './settings';
 import { Converter } from './converter';
 import { DatalabConverter } from './converters/datalabConverter';
 import { MarkerApiDockerConverter } from './converters/markerApiDocker';
-import { PythonAPIConverter } from './converters/markerPythonApi';
+import { PythonLocalAPIConverter } from "./converters/markerLocalPythonApi";
+import { PythonCloudAPIConverter } from './converters/markerCloudPythonApi';
 import { MistralAIConverter } from './converters/mistralaiConverter';
 
 export default class Marker extends Plugin {
@@ -26,8 +27,11 @@ export default class Marker extends Plugin {
       case 'selfhosted':
         this.converter = new MarkerApiDockerConverter();
         break;
-      case 'python-api':
-        this.converter = new PythonAPIConverter();
+      case 'python-local-api':
+        this.converter = new PythonLocalAPIConverter();
+        break;
+      case 'python-cloud-api':
+        this.converter = new PythonCloudAPIConverter();
         break;
       case 'mistralai':
         this.converter = new MistralAIConverter();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -74,7 +74,8 @@ export class MarkerSettingTab extends PluginSettingTab {
         dropdown
           .addOption('datalab', 'Datalab')
           .addOption('selfhosted', 'Selfhosted')
-          .addOption('python-api', 'Python API')
+          .addOption('python-local-api', 'Python API')
+          .addOption('python-cloud-api', 'Python API')
           .addOption('mistralai', 'MistralAI')
           .setValue(this.plugin.settings.apiEndpoint)
           .onChange(async (value) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -74,8 +74,8 @@ export class MarkerSettingTab extends PluginSettingTab {
         dropdown
           .addOption('datalab', 'Datalab')
           .addOption('selfhosted', 'Selfhosted')
-          .addOption('python-local-api', 'Python API')
-          .addOption('python-cloud-api', 'Python API')
+          .addOption('python-local-api', 'Python Local API')
+          .addOption('python-cloud-api', 'Python Cloud API')
           .addOption('mistralai', 'MistralAI')
           .setValue(this.plugin.settings.apiEndpoint)
           .onChange(async (value) => {

--- a/src/utils/multipartUtils.ts
+++ b/src/utils/multipartUtils.ts
@@ -1,0 +1,114 @@
+import {TFile} from "obsidian";
+
+// Interface for multipart form field
+export interface FormField {
+  name: string;
+  value: string | boolean | number | null;
+}
+
+// Return type from building the multipart
+export interface MultipartRequestBody {
+  body: ArrayBuffer;
+  boundary: string;
+}
+
+export class MarkerMultipartRequest {
+  private constructor() {}
+
+  /**
+   * Builds the multipart request body
+   */
+  public static build(
+    boundary: string,
+    file: TFile,
+    fileContent: ArrayBuffer,
+    fields: FormField[]
+  ): MultipartRequestBody {
+    const parts: (string | Uint8Array)[] = [];
+
+    // Add the file part
+    const contentType = this.getContentTypeForFile(file);
+    parts.push(
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${file.name}"\r\n` +
+      `Content-Type: ${contentType}\r\n\r\n`
+    );
+    parts.push(new Uint8Array(fileContent));
+    parts.push('\r\n');
+
+    // Add other form fields
+    for (const field of fields) {
+      if (field.value !== null && field.value !== undefined) {
+        parts.push(
+          `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="${field.name}"\r\n\r\n${field.value}\r\n`
+        );
+      }
+    }
+
+    // Add closing boundary
+    parts.push(`--${boundary}--\r\n`);
+
+    // Combine all parts into a single ArrayBuffer
+    return {
+      body: this.combinePartsToArrayBuffer(parts),
+      boundary: boundary,
+    };
+  }
+
+  /**
+   * Determines the content type for a file based on its extension
+   */
+  public static getContentTypeForFile(file: TFile): string {
+    switch (file.extension) {
+      case 'pdf':
+        return 'application/pdf';
+      case 'docx':
+      case 'doc':
+        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      case 'pptx':
+      case 'ppt':
+        return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'webp':
+        return 'image/webp';
+      default:
+        console.error(
+          `Unrecognized file extension: ${file.extension}, using generic content type`
+        );
+        return 'application/octet-stream';
+    }
+  }
+
+  /**
+   * Combines parts into a single ArrayBuffer
+   */
+  public static combinePartsToArrayBuffer(
+    parts: (string | Uint8Array)[]
+  ): ArrayBuffer {
+    // Convert string parts to Uint8Array
+    const bodyParts = parts.map((part) =>
+      typeof part === 'string' ? new TextEncoder().encode(part) : part
+    );
+
+    // Calculate total length
+    const bodyLength = bodyParts.reduce(
+      (acc, part) => acc + part.byteLength,
+      0
+    );
+
+    // Create and fill the combined buffer
+    const body = new Uint8Array(bodyLength);
+    let offset = 0;
+    for (const part of bodyParts) {
+      body.set(part, offset);
+      offset += part.byteLength;
+    }
+
+    return body.buffer;
+  }
+}


### PR DESCRIPTION
## Problem

The current Python API converter sends a local file path to the Marker server. This works when the Marker server is running on the same machine as Obsidian, but it prevents using the Python API remotely (for example on WSL, a Docker host, another computer on the network, or a cloud VM), because the remote server cannot access the local filesystem path.

## Proposed Solution

Allow the Python API converter to upload the document using multipart form data instead of requiring a filesystem path. I implemented this approach in my [fork](https://github.com/random-logic/obsidian-marker). Here are the changes I made:

* Added a new "Python Cloud API" converter that uploads files directly to the Python API /marker/upload endpoint.
* Reused the multipart upload pattern already used by the Datalab converter, with the appropriate form fields required by the Python API.
* Extracted the multipart request builder into a reusable static utility class.
* Simplified a duplicated multipart helper fragment in the Docker API converter to reuse the same implementation.
* Added the new converter as a selectable option in plugin settings.

If this approach aligns with the project's direction, I'd be happy to open a pull request for review.

## Unofficial Release

If anyone wants to use 1.4.8 with my changes, I made an [unofficial release](https://github.com/random-logic/obsidian-marker/releases/tag/1.4.8) on my fork.